### PR TITLE
Fix Faraday deprecation warning

### DIFF
--- a/lib/tweetkit/connection.rb
+++ b/lib/tweetkit/connection.rb
@@ -27,7 +27,7 @@ module Tweetkit
           if auth_type == 'oauth1'
             conn.request :oauth, consumer_key: @consumer_key, consumer_secret: @consumer_secret
           else
-            conn.authorization :Bearer, @bearer_token
+            conn.request :authorization, 'Bearer', @bearer_token
           end
         end
         response = connection.get(url)


### PR DESCRIPTION
This resolves the following Faraday deprecation warning:
```
WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:authorization, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
```

`conn.request :authorization` appears to be supported by all Faraday versions >= 0.9, as specified by the gemspec.