### PR TITLE
Add the ability to post + delete a Tweet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,5 @@
 BEARER_TOKEN=<your-bearer-token>
+CONSUMER_KEY=<your-consumer-key>
+CONSUMER_SECRET=<your-consumer-secret>
+ACCESS_TOKEN=<your-access-token>
+ACCESS_TOKEN_SECRET=<your-access-token-secret>

--- a/lib/tweetkit/auth.rb
+++ b/lib/tweetkit/auth.rb
@@ -1,9 +1,5 @@
 module Tweetkit
   module Auth
-    def basic_auth?
-      !!(@login && @password)
-    end
-
     def token_auth?
       !!(@access_token && @access_token_secret)
     end

--- a/lib/tweetkit/auth.rb
+++ b/lib/tweetkit/auth.rb
@@ -1,7 +1,7 @@
 module Tweetkit
   module Auth
     def token_auth?
-      !!(@access_token && @access_token_secret)
+      !!(@consumer_key && @consumer_secret && @access_token && @access_token_secret)
     end
 
     def bearer_auth?

--- a/lib/tweetkit/client/tweets.rb
+++ b/lib/tweetkit/client/tweets.rb
@@ -21,6 +21,14 @@ module Tweetkit
         search.evaluate(&block) if block_given?
         get 'tweets/search/recent', **options.merge!({ query: search.current_query })
       end
+
+      def post_tweet(**options)
+        post "tweets", **options
+      end
+
+      def delete_tweet(id)
+        delete "tweets/#{id}"
+      end
     end
   end
 end

--- a/lib/tweetkit/connection.rb
+++ b/lib/tweetkit/connection.rb
@@ -41,13 +41,6 @@ module Tweetkit
       raise e
     end
 
-    def auth_token(type = 'bearer')
-      case type
-      when 'bearer'
-        @bearer_token
-      end
-    end
-
     def build_fields(options)
       fields = {}
       fields_ = options.delete(:fields)

--- a/lib/tweetkit/connection.rb
+++ b/lib/tweetkit/connection.rb
@@ -16,26 +16,45 @@ module Tweetkit
       request :get, endpoint, parse_query_and_convenience_headers(options)
     end
 
+    def post(endpoint, **options)
+      request :post, endpoint, parse_query_and_convenience_headers(options)
+    end
+
+    def put(endpoint, **options)
+      request :put, endpoint, parse_query_and_convenience_headers(options)
+    end
+
+    def delete(endpoint, **options)
+      request :delete, endpoint, parse_query_and_convenience_headers(options)
+    end
+
     def request(method, endpoint, data, **options)
-      auth_type = options.delete(:auth_type)
       url = URI.parse("#{BASE_URL}#{endpoint}")
       @previous_url = url
       @previous_query = data
 
-      if method == :get
-        connection = Faraday.new(params: data) do |conn|
-          if auth_type == 'oauth1'
-            conn.request :oauth, consumer_key: @consumer_key, consumer_secret: @consumer_secret
-          else
-            conn.request :authorization, 'Bearer', @bearer_token
-          end
+      connection = Faraday.new do |conn|
+        if token_auth?
+          conn.request :oauth, consumer_key: @consumer_key, consumer_secret: @consumer_secret,
+                               token: @access_token, token_secret: @access_token_secret
+        elsif bearer_auth?
+          conn.request :authorization, 'Bearer', @bearer_token
+        else
+          raise NotImplementedError, 'No known authentication types were configured'
         end
-        response = connection.get(url)
-      else
-        connection = Faraday.new do |f|
-        end
-        response = connection.post(url)
       end
+
+      response = case method
+                 when :get
+                   connection.get(url, data)
+                 when :post
+                   connection.post(url, data.to_json, 'Content-Type' => 'application/json')
+                 when :put
+                   connection.put(url, data.to_json, 'Content-Type' => 'application/json')
+                 when :delete
+                   connection.delete(url, data.to_json, 'Content-Type' => 'application/json')
+                 end
+
       Tweetkit::Response::Tweets.new response, connection: connection, twitter_request: { previous_url: @previous_url, previous_query: @previous_query }
     rescue StandardError => e
       raise e

--- a/spec/client/tweets_spec.rb
+++ b/spec/client/tweets_spec.rb
@@ -38,4 +38,25 @@ describe Tweetkit::Client::Tweets do
       end
     end
   end
+
+  context 'when user context is required' do
+    let(:client) { client_types[:access_token] }
+
+    describe '.post_tweet' do
+      it 'posts text' do
+        response = client.post_tweet(text: 'Hello world')
+        expect(response.tweet.text).not_to be_empty
+      end
+    end
+
+    describe '.delete_tweet' do
+      it 'deletes a tweet' do
+        create_response = client.post_tweet(text: 'Hello world')
+        tweet_id = create_response.tweet.id.to_i
+        delete_response = client.delete_tweet(tweet_id)
+
+        expect(delete_response.response.dig('data', 'deleted')).to be(true)
+      end
+    end
+  end
 end

--- a/spec/client/tweets_spec.rb
+++ b/spec/client/tweets_spec.rb
@@ -1,31 +1,41 @@
 require_relative '../spec_helper'
 
 describe Tweetkit::Client::Tweets do
-  before(:each) do
-    @client = Tweetkit::Client.new(bearer_token: ENV['BEARER_TOKEN'])
-  end
+  client_types = {
+    bearer_token: Tweetkit::Client.new(bearer_token: ENV['BEARER_TOKEN']),
+    access_token: Tweetkit::Client.new(
+      consumer_key: ENV['CONSUMER_KEY'],
+      consumer_secret: ENV['CONSUMER_SECRET'],
+      access_token: ENV['ACCESS_TOKEN'],
+      access_token_secret: ENV['ACCESS_TOKEN_SECRET'],
+    ),
+  }
 
-  describe '.tweet' do
-    it 'accepts an ID and gets a tweet' do
-      response = @client.tweet(1228393702244134912)
+  client_types.each do |client_type, client|
+    context "with #{client_type} client" do
+      describe '.tweet' do
+        it 'accepts an ID and gets a tweet' do
+          response = client.tweet(1228393702244134912)
 
-      expect(response.tweet.text).not_to be_empty
-    end
-  end
+          expect(response.tweet.text).not_to be_empty
+        end
+      end
 
-  describe '.tweets' do
-    it 'accepts an array of IDs and gets the tweets' do
-      response = @client.tweets([1228393702244134912, 1227640996038684673])
+      describe '.tweets' do
+        it 'accepts an array of IDs and gets the tweets' do
+          response = client.tweets([1228393702244134912, 1227640996038684673])
 
-      expect(response.tweets.size).to eq(2)
-      expect(response.tweets.first.text).not_to be_empty
-    end
+          expect(response.tweets.size).to eq(2)
+          expect(response.tweets.first.text).not_to be_empty
+        end
 
-    it 'accepts comma-separated string of IDs and gets the tweets' do
-      response = @client.tweets([1228393702244134912, 1227640996038684673])
+        it 'accepts comma-separated string of IDs and gets the tweets' do
+          response = client.tweets([1228393702244134912, 1227640996038684673])
 
-      expect(response.tweets.size).to eq(2)
-      expect(response.tweets.first.text).not_to be_empty
+          expect(response.tweets.size).to eq(2)
+          expect(response.tweets.first.text).not_to be_empty
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
A few more updates!

- Removed some unused methods
- Added the ability to authenticate with an [OAuth user context](https://developer.twitter.com/en/docs/authentication/overview)
- Added `client.post_tweet` and `client.delete_tweet`, and corresponding tests

This is likely where I'll leave things for now, as it adds the basic Twitter API v2 functionality that I'm most interested in (the ability to manage Tweets). I hope this is a useful contribution!