### PR TITLE
Fix naming to map to current implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ Or install it yourself as:
   client = Tweetkit::Client.new(bearer_token: 'YOUR_BEARER_TOKEN_HERE')
 
   # Initializing via options with OAuth 1.0 credentials
-  client = Tweetkit::Client.new(bearer_token: 'YOUR_BEARER_TOKEN_HERE', consumer_key: 'YOUR_API_KEY_HERE', consumer_token: 'YOUR_API_TOKEN_HERE')
+  client = Tweetkit::Client.new(bearer_token: 'YOUR_BEARER_TOKEN_HERE', consumer_key: 'YOUR_CONSUMER_KEY_HERE', consumer_secret: 'YOUR_CONSUMER_SECRET_HERE')
 
   # You can also initialize the client with a block
   client = Tweetkit::Client.new do |config|
     config.bearer_token = 'YOUR_BEARER_TOKEN_HERE'
-    config.consumer_key = 'YOUR_API_KEY_HERE'
-    config.consumer_token = 'YOUR_API_TOKEN_HERE'
+    config.consumer_key = 'YOUR_CONSUMER_KEY_HERE'
+    config.consumer_secret = 'YOUR_CONSUMER_SECRET_HERE'
   end
 ```
 


### PR DESCRIPTION
As I just ran into this problem while copy pasting from the documentation, looks like the naming got changed to be in line with Twitter naming.