### PR TITLE
[WIP] adds timeline requests

### DIFF
--- a/lib/tweetkit/client.rb
+++ b/lib/tweetkit/client.rb
@@ -1,10 +1,12 @@
 require 'tweetkit/connection'
 require 'tweetkit/client/tweets'
+require 'tweetkit/client/timeline'
 
 module Tweetkit
   class Client
     include Tweetkit::Connection
     include Tweetkit::Client::Tweets
+    include Tweetkit::Client::Timeline
 
     attr_accessor :access_token, :access_token_secret, :bearer_token, :consumer_key, :consumer_secret, :email, :password
 

--- a/lib/tweetkit/client/timeline.rb
+++ b/lib/tweetkit/client/timeline.rb
@@ -1,0 +1,9 @@
+module Tweetkit
+  class Client
+    module Timeline
+      def timeline(id, **options)
+        get "users/#{id}/tweets", **options
+      end
+    end
+  end
+end

--- a/lib/tweetkit/version.rb
+++ b/lib/tweetkit/version.rb
@@ -1,3 +1,3 @@
 module Tweetkit
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/spec/client/timeline_spec.rb
+++ b/spec/client/timeline_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../spec_helper'
+
+describe Tweetkit::Client::Timeline do
+  client_types = {
+    bearer_token: Tweetkit::Client.new(bearer_token: ENV['BEARER_TOKEN']),
+    access_token: Tweetkit::Client.new(
+      consumer_key: ENV['CONSUMER_KEY'],
+      consumer_secret: ENV['CONSUMER_SECRET'],
+      access_token: ENV['ACCESS_TOKEN'],
+      access_token_secret: ENV['ACCESS_TOKEN_SECRET'],
+    ),
+  }
+
+  client_types.each do |client_type, client|
+    context "with #{client_type} client" do
+      describe '.timeline' do
+        it 'accepts a twitter user ID and gets a timeline' do
+          response = client.timeline(21720472)
+
+          expect(response.tweets.length).to eq(10)
+          expect(response.tweets.first.text).not_to be_empty
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I make extensive use of the timeline endpoint:
https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference/get-users-id-tweets

I had already built up a bunch of code in a library but using a gem that the community is pointing to would be beneficial.

Hopefully, this code is acceptable. Let me know if you want any changes. Tweets and Mentions are separate endpoints under the "timeline" umbrella, so if you'd prefer a reorganization here, I'm all for it.